### PR TITLE
Dam 153 use ssm for username password

### DIFF
--- a/amazonmq/data-remote-state.tf
+++ b/amazonmq/data-remote-state.tf
@@ -50,3 +50,17 @@ data "terraform_remote_state" "ecr" {
     region = "${var.region}"
   }
 }
+
+
+#-------------------------------------------------------------
+# Getting the vpc
+#-------------------------------------------------------------
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket_name}"
+    key    = "vpc/terraform.tfstate"
+    region = "${var.region}"
+  }
+}

--- a/amazonmq/main.tf
+++ b/amazonmq/main.tf
@@ -11,8 +11,9 @@ provider "aws" {
 locals {
   sg_map_ids = "${data.terraform_remote_state.common.sg_map_ids}"
 
-  int_lb_security_groups = ["${local.sg_map_ids["internal_lb_sg_id"]}",
-                            "${local.sg_map_ids["bastion_in_sg_id"]}"]
+  int_lb_security_groups = [
+    "${local.sg_map_ids["internal_lb_sg_id"]}",
+    "${local.sg_map_ids["bastion_in_sg_id"]}"]
 
   int_amq_security_groups = "${data.terraform_remote_state.common.amazonmq_inst_sg_id}"
 
@@ -23,7 +24,22 @@ locals {
 
   # Setup a broker instance count based on the broker deployment mode
   broker_instances = "${(var.aws_broker_deployment_mode) == "SINGLE_INSTANCE" ? 1 : 2}"
-  broker_subnet_ids  = ["${slice(local.private_subnet_ids, 0, local.broker_instances)}"]
+  broker_subnet_ids = [
+    "${slice(local.private_subnet_ids, 0, local.broker_instances)}"]
+
+  # Construct the credentials_ssm_path from the common remote state variables tags.application and tags.environment_name and the fixed string
+  credentials_ssm_path = "/${data.terraform_remote_state.vpc.environment_name}/${data.terraform_remote_state.vpc.tags.application}/weblogic/spg-domain"
+}
+
+#-------------------------------------------------------------
+## Getting the remote broker username/password from SSM
+#-------------------------------------------------------------
+data "aws_ssm_parameter" "remote_broker_username" {
+  name = "${local.credentials_ssm_path}/remote_broker_username"
+}
+
+data "aws_ssm_parameter" "remote_broker_password" {
+  name = "${local.credentials_ssm_path}/remote_broker_password"
 }
 
 resource "aws_mq_broker" "SPG" {
@@ -42,8 +58,8 @@ resource "aws_mq_broker" "SPG" {
   subnet_ids         = ["${local.broker_subnet_ids}"]
 
   user {
-    username = "spgsmx"
-    password = "spgsmx1000000"
+    username = "${data.aws_ssm_parameter.remote_broker_username.value}"
+    password = "${data.aws_ssm_parameter.remote_broker_password.value}"
     console_access = "true"
   }
 }
@@ -99,6 +115,7 @@ data "null_data_source" "broker_export_port" {
   inputs = {
         broker_ssl_port = "${element(slice(split(":", aws_mq_broker.SPG.instances.0.endpoints[0]), 2,3),0)}"
   }
+  depends_on = ["aws_mq_broker.SPG"]
 }
 
 # Construct the amazon MQ connection url from the dns names and depending on how many instances
@@ -107,14 +124,17 @@ data "null_data_source" "broker_export_url" {
 
   inputs = {
 
-    broker_connect_url =  "${local.broker_instances == 1 ?
+    broker_connect_url =  "${(local.broker_instances) == 1 ?
+
                                 format("ssl://%s:%s",
                                         aws_route53_record.dns_spg_amq_a_int_entry.fqdn,
-                                        data.null_data_source.broker_export_port.outputs["broker_ssl_port"]):
+                                        data.null_data_source.broker_export_port.outputs["broker_ssl_port"]) :
+
                                 format("failover(ssl://%s:%s, ssl://%s:%s)",
                                         aws_route53_record.dns_spg_amq_a_int_entry.fqdn,
                                         data.null_data_source.broker_export_port.outputs["broker_ssl_port"],
                                         aws_route53_record.dns_spg_amq_b_int_entry.fqdn,
                                         data.null_data_source.broker_export_port.outputs["broker_ssl_port"])}"
   }
+  depends_on = ["aws_mq_broker.SPG"]
 }

--- a/amazonmq/output.tf
+++ b/amazonmq/output.tf
@@ -1,3 +1,19 @@
 output "amazon_mq_broker_connect_url" {
   value = "${data.null_data_source.broker_export_url.outputs["broker_connect_url"]}"
 }
+
+output "aws_ssm_credentials_path" {
+  value = "${local.credentials_ssm_path}"
+}
+
+output "broker_username" {
+  value = "${data.aws_ssm_parameter.remote_broker_username.value}"
+}
+
+output "broker_password" {
+  value = "${data.aws_ssm_parameter.remote_broker_password.value}"
+}
+
+output "broker_instances" {
+  value = "${local.broker_instances}"
+}

--- a/security-groups/main.tf
+++ b/security-groups/main.tf
@@ -53,7 +53,7 @@ data "terraform_remote_state" "nat" {
 
 ### Extract the new security group rules
 #-------------------------------------------------------------
-data "terraform_remote_state" "sec-group-rules" {
+data "terraform_remote_state" "security" {
   backend = "s3"
 
   config {
@@ -92,9 +92,7 @@ locals {
   internal_inst_sg_id = "${local.sg_map_ids["internal_inst_sg_id"]}"
   external_lb_sg_id   = "${local.sg_map_ids["external_lb_sg_id"]}"
   external_inst_sg_id = "${local.sg_map_ids["external_inst_sg_id"]}"
-  //amazonmq_inst_sg_id = "${local.sg_map_ids["amazonmq_inst_sg_id"]}"
   amazonmq_inst_sg_id = "${data.terraform_remote_state.common.amazonmq_inst_sg_id}"
-  #spg_outbound_id     = "${local.sg_map_ids["outbound_sg_id"]}"
-  spg_outbound_id     = "${data.terraform_remote_state.sec-group-rules.spg_common_outbound_sg_id}"
+  spg_outbound_id     = "${data.terraform_remote_state.security.spg_common_outbound_sg_id}"
 
 }

--- a/security-groups/main.tf
+++ b/security-groups/main.tf
@@ -58,7 +58,7 @@ data "terraform_remote_state" "security" {
 
   config {
     bucket = "${var.remote_state_bucket_name}"
-    key    = "spg/security-group-and-rules/terraform.tfstate"
+    key    = "spg/security-groups-and-rules/terraform.tfstate"
     region = "${var.region}"
   }
 }

--- a/security-groups/main.tf
+++ b/security-groups/main.tf
@@ -51,6 +51,18 @@ data "terraform_remote_state" "nat" {
   }
 }
 
+### Extract the new security group rules
+#-------------------------------------------------------------
+data "terraform_remote_state" "sec-group-rules" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket_name}"
+    key    = "spg/security-group-and-rules/terraform.tfstate"
+    region = "${var.region}"
+  }
+}
+
 ####################################################
 # Locals
 ####################################################
@@ -82,6 +94,7 @@ locals {
   external_inst_sg_id = "${local.sg_map_ids["external_inst_sg_id"]}"
   //amazonmq_inst_sg_id = "${local.sg_map_ids["amazonmq_inst_sg_id"]}"
   amazonmq_inst_sg_id = "${data.terraform_remote_state.common.amazonmq_inst_sg_id}"
-  spg_outbound_id     = "${local.sg_map_ids["outbound_sg_id"]}"
+  #spg_outbound_id     = "${local.sg_map_ids["outbound_sg_id"]}"
+  spg_outbound_id     = "${data.terraform_remote_state.sec-group-rules.spg_common_outbound_sg_id}"
 
 }


### PR DESCRIPTION
This branch pulls the username and password stored in the SSM and uses these values to build the AmazonMQ broker

It also fixes a change in the Source Security Group to the new value created in the security-groups-and-rules folder

We still need to address Delius and Alfresco inbound traffic and extracting the Broker username/password in our Ansible build script to write to our spg configuration