### PR TITLE
add 8162 rules from cidr block

### DIFF
--- a/security-groups-and-rules/amazon-instance.tf
+++ b/security-groups-and-rules/amazon-instance.tf
@@ -1,18 +1,35 @@
 // source security is the range of mpx instances e.g. dlc-sandpit-spgw-sg-outbound-traffic
 
-//Allows access to the ActiveMQ console via bastion proxy - TODO this should be SSL
+//Allows https access to the ActiveMQ console via bastion proxy (bastion proxy needs that port in egress)
 resource "aws_security_group_rule" "amazonmq_inst_sg_ingress_webconsole" {
   security_group_id        = "${data.terraform_remote_state.vpc-security-groups.sg_amazonmq_in}"
   type                     = "ingress"
   from_port                = "8162"
   to_port                  = "8162"
   protocol                 = "tcp"
-//  source_security_group_id = "${aws_security_group.spg_common_outbound.id}"
   cidr_blocks             = [ "${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}" ]
   description              = "${local.common_name}-instance-amazonmq-sg"
 }
 
+
 //Allows access to the ActiveMQ console from within the SPGW security group
+//TODO should cidr blocks below be replaced with  source_security_group_id = "${aws_security_group.spg_common_outbound.id}"
+//TODO tf does not match above statement
+resource "aws_security_group_rule" "amazonmq_inst_sg_ingress_jms_openwire" {
+  security_group_id        = "${data.terraform_remote_state.vpc-security-groups.sg_amazonmq_in}"
+  type                     = "ingress"
+  from_port                = "8162"
+  to_port                  = "8162"
+  protocol                 = "tcp"
+  cidr_blocks              = ["${local.private_cidr_block}"]
+  description              = "${local.common_name}-instance-amazonmq-sg"
+}
+
+
+
+//Allows access to the ActiveMQ console from within the SPGW security group
+//TODO should cidr blocks below be replaced with  source_security_group_id = "${aws_security_group.spg_common_outbound.id}"
+//TODO tf does not match above statement
 resource "aws_security_group_rule" "amazonmq_inst_sg_ingress_jms_openwire" {
   security_group_id        = "${data.terraform_remote_state.vpc-security-groups.sg_amazonmq_in}"
   type                     = "ingress"


### PR DESCRIPTION
bastion proxy egress has been reduced, plus if we go in via mpx box we can use the internal  DNS names