### PR TITLE
ALS-716 removed dependency on short environment identifier for dtt

### DIFF
--- a/iam/main.tf
+++ b/iam/main.tf
@@ -17,10 +17,10 @@ locals {
   spg_app_name                 = "${data.terraform_remote_state.common.spg_app_name}"
   environment_identifier       = "${data.terraform_remote_state.common.environment_identifier}"
   account_id                   = "${data.terraform_remote_state.common.common_account_id}"
-  #workaround for training-test exceeding 64 chars
 
-  short_environment_identifier = "${var.short_environment_identifier}"
-  dynamic_environment_identifier = "${(local.environment_identifier == "tf-eu-west-2-hmpps-delius-training-test") ? local.short_environment_identifier : local.environment_identifier}"
+  #workaround for training-test exceeding 64 chars & external change of environment prefix (was referencing short_environment_identifier)
+  historic_dtt_prefix          = "tf-dtt-training-test"
+  dynamic_environment_identifier = "${(local.environment_identifier == "tf-eu-west-2-hmpps-delius-training-test") ? local.historic_dtt_prefix : local.environment_identifier}"
 
   common_name                  = "${local.dynamic_environment_identifier}-${var.spg_app_name}"
 

--- a/iam/variables.tf
+++ b/iam/variables.tf
@@ -20,7 +20,3 @@ variable "depends_on" {
   default = []
   type    = "list"
 }
-
-variable "short_environment_identifier" {
-  description = "short resource label or name"
-}


### PR DESCRIPTION
found that DTT also has had its environment changed as well as potest

have removed references to short environment identifier and hardcoded it to its current value